### PR TITLE
Add frontend lint and build workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,29 @@
+name: Frontend
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm lint
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- add new GitHub Actions workflow to lint and build the frontend

## Testing
- `pnpm install` *(fails: unable to access registry)*
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dca6cbe1c8321ac68479b89759fc6