### PR TITLE
Fix frontend CI pnpm setup

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,16 +14,16 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: frontend/pnpm-lock.yaml
       - uses: pnpm/action-setup@v2
         with:
           version: 9
           run_install: false
           add-to-path: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install
       - name: Lint

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,8 +18,11 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
-      - name: Install pnpm
-        run: corepack prepare pnpm@9 --activate
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
       - name: Install dependencies
         run: pnpm install
       - name: Lint

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           version: 9
           run_install: false
+          add-to-path: true
       - name: Install dependencies
         run: pnpm install
       - name: Lint

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,9 +18,8 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
+      - name: Install pnpm
+        run: corepack prepare pnpm@9 --activate
       - name: Install dependencies
         run: pnpm install
       - name: Lint


### PR DESCRIPTION
## Summary
- install pnpm in frontend workflow using corepack to ensure the command is on PATH

## Testing
- `pnpm lint` *(fails: ESLint config missing)*
- `pnpm install` *(fails: 403 fetching from registry)*
- `dotnet test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684dcdf3513083219c206259e2cd1844